### PR TITLE
Update pgsql.md to fix missing option

### DIFF
--- a/_manual/options/pgsql.md
+++ b/_manual/options/pgsql.md
@@ -3,7 +3,7 @@
 | -i, \--tablespace-index=TABLESPC      | Store all indexes in the PostgreSQL tablespace `TABLESPC`. This option also affects the middle tables. |
 | \--tablespace-main-data=TABLESPC      | Store the data tables in the PostgreSQL tablespace `TABLESPC`. |
 | \--tablespace-main-index=TABLESPC     | Store the indexes in the PostgreSQL tablespace `TABLESPC`. |
-| \--latlong                            | Store coordinates in degrees of latitude & longitude. |
+| -l, \--latlong                        | Store coordinates in degrees of latitude & longitude. |
 | -m, \--merc                           | Store coordinates in Spherical Mercator (Web Mercator, EPSG:3857) (the default). |
 | -E, \--proj=SRID                      | Use projection EPSG:`SRID`. |
 | -p, \--prefix=PREFIX                  | Prefix for table names (default: `planet_osm`). This option affects the middle as well as the pgsql output table names. |


### PR DESCRIPTION
The command line options seem to be missing the '-l' option (synonymous to '--latlong'), which appears to be still valid input in the latest release of osm2pgsql (1.9.2) based on a quick test, properly importing data as 4326.